### PR TITLE
Fixes "Cannot download embed-only video" error

### DIFF
--- a/cybrary-video-downloader.py
+++ b/cybrary-video-downloader.py
@@ -55,7 +55,7 @@ def downloadVideo(videoLink, quality):
 
 	# *nix
 	else:
-		command = "youtube-dl -cif http-%sp %s" % (quality, videoLink)
+		command = "youtube-dl -cif http-%sp %s --referer https://www.cybrary.it/" % (quality, videoLink)
 	os.system(command)
 
 # Main function

--- a/cybrary-video-downloader.py
+++ b/cybrary-video-downloader.py
@@ -42,7 +42,10 @@ def downloadCourseVideos(quality, course):
 		lessonHTML = (session.get(lessonLink.get('href'))).text
 		parsedLessonHTML = BeautifulSoup(lessonHTML, 'html.parser')
 		videoLink = parsedLessonHTML.find('iframe', attrs={'class':'sv_lessonvideo'})
-		downloadVideo(videoLink.get('src'), quality)
+		try:
+             		downloadVideo(videoLink.get('src'), quality)
+         	except Exception as e:
+             		print e
 
 # Download video using youtube-dl
 def downloadVideo(videoLink, quality):


### PR DESCRIPTION
I get the ERROR: Cannot download embed-only video without embedding URL. Please call youtube-dl with the URL of the page that embeds this video when attempting to download videos. In case anyone gets this error, adding the `--referer` option fixed it for me.